### PR TITLE
negative timer display only shows sign at beginning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
 		"url": "git+https://github.com/bitfocus/companion-module-h2r-graphics.git"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.0.2",
-		"got": "^12.5.3",
+		"@companion-module/base": "^1.7.0",
+		"got": "^14.0.0",
 		"socket.io-client": "^4.6.0"
 	},
 	"devDependencies": {
-		"@companion-module/tools": "^0.5.1"
+		"@companion-module/tools": "^1.4.2"
 	},
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"type": "module"

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -7,10 +7,9 @@ let socket = null
 const intervalIdObj = {}
 
 const toTimeString = (timeLeft, amount = 'full') => {
-	const tl = timeLeft + 500
-	const hours = Math.floor((tl / (1000 * 60 * 60)) % 24) || 0
-	const minutes = Math.floor((tl / (1000 * 60)) % 60) || 0
-	const seconds = Math.floor((tl / 1000) % 60) || 0
+	const hours = Math.floor((timeLeft / (1000 * 60 * 60)) % 24) || 0
+	const minutes = Math.floor((timeLeft / (1000 * 60)) % 60) || 0
+	const seconds = Math.floor((timeLeft / 1000) % 60) || 0
 
 	if (amount == 'hh') return hours.toString().padStart(2, '0')
 	if (amount == 'mm') return minutes.toString().padStart(2, '0')

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -16,9 +16,11 @@ const toTimeString = (timeLeft, amount = 'full') => {
 	if (amount == 'mm') return minutes.toString().padStart(2, '0')
 	if (amount == 'ss') return seconds.toString().padStart(2, '0')
 
-	return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds
-		.toString()
-		.padStart(2, '0')}`
+	const hoursString = `${hours<0 ? '-':''}${Math.abs(hours).toString().padStart(2, '0')}`
+	const minutesString = `${Math.abs(minutes).toString().padStart(2, '0')}`
+	const secondsString = `${Math.abs(seconds).toString().padStart(2, '0')}`
+
+	return `${hoursString}:${minutesString}:${secondsString}`
 }
 
 function startStopTimer(self, timerObj) {

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -31,19 +31,20 @@ function startStopTimer(self, timerObj) {
 
 		if (timeCue.type === 'time_countup' || timeCue.type === 'big_time_countup') {
 			timeLeft = currentTime - timeCue.startedAt
-		} else if (timeCue.type === 'time_countdown' || timeCue.type === 'big_time_countdown') {
-			timeLeft = timeCue.endAt - currentTime
-		} else if (timeCue.type === 'utility_speaker_timer') {
-			timeLeft = timeCue.endAt - currentTime
+		} else if (timeCue.type === 'time_countdown' || timeCue.type === 'big_time_countdown' || timeCue.type === 'utility_speaker_timer') {
+			if(timeCue.state === 'reset'){
+				timeLeft = Number.parseInt(timeCue.duration, 10)
+			}else{
+				timeLeft = timeCue.endAt - currentTime
+			}
 		} else if (timeCue.type === 'time_to_tod' || timeCue.type === 'big_time_to_tod') {
 			let t = new Date(timeCue?.endTime)?.getTime() || 0
 			timeLeft = t - currentTime
 		}
 
-		if (['paused', 'reset'].includes(timerObj.state)) {
+		if (['paused', 'reset'].includes(timeCue.state)) {
 			clearInterval(intervalIdObj[timerKey])
 			delete intervalIdObj[timerKey]
-
 			return self.setVariableValues({
 				[`graphic_${timerKey}_contents`]: `⏸ ${toTimeString(timeLeft)}`,
 				[`graphic_${timerKey}_hh`]: `${toTimeString(timeLeft, 'hh')}`,
@@ -52,7 +53,7 @@ function startStopTimer(self, timerObj) {
 			})
 		}
 
-		self.log('debug', `INTERVAL ${timerObj.id} ${JSON.stringify(timerObj)}`)
+		self.log('debug', `INTERVAL ${timeCue.id} ${JSON.stringify(timeCue)}`)
 		return self.setVariableValues({
 			[`graphic_${timerKey}_contents`]: `${toTimeString(timeLeft)}`,
 			[`graphic_${timerKey}_hh`]: `${toTimeString(timeLeft, 'hh')}`,


### PR DESCRIPTION
The timer variable `full` variable shows the negative sign for all 3 places on the timer. Like this.
<img width="63" alt="Screen Shot 2023-12-16 at 5 07 26 PM" src="https://github.com/bitfocus/companion-module-h2r-graphics/assets/18341515/b5e76fad-e470-41b1-8f95-cbab6f351c76">

This PR will correct the `full` mode to just show the leading negative sign. Like this.
<img width="63" alt="Screen Shot 2023-12-16 at 5 07 26 PM" src="https://github.com/bitfocus/companion-module-h2r-graphics/assets/18341515/fb69f1c9-677d-4adf-9826-8d27e59fbe45">


