### PR TITLE
Add new graphic variables and config to use them on preset buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,18 @@ class H2RGraphicsInstance extends InstanceBase {
 				width: 3,
 				default: 'ABCD',
 			},
+			{
+				type: 'dropdown',
+				id: 'lowerThirdPresetLabelSource',
+				label: 'Text Format for Lower Third Preset Buttons',
+				width: 6,
+				default: 'contents',
+				choices: [
+					{ id: 'contents', label: 'Line 1, Line 2' },
+					{ id: 'first_line', label: 'Line 1' },
+					{ id: 'label', label: 'Label (shows ID if label is empty)' },
+				],
+			},
 		]
 	}
 

--- a/src/presets.js
+++ b/src/presets.js
@@ -55,12 +55,16 @@ export const initPresets = (self) => {
 	const createPresetShowHide = (category, item) => {
 		let bgColour = graphicColours(item.type).bgColour
 		let pngIcon = graphicIcons(item.type).png
+		let labelSource = ['lower_third', 'lower_third_animated'].includes(item.type)
+			? self.config.lowerThirdPresetLabelSource || 'contents'
+			: 'contents'
+
 		return {
 			category,
 			type: 'button',
 			name: replaceWithDataSource(graphicToReadableLabel(item).label, SELECTED_PROJECT_VARIABLES),
 			style: {
-				text: `$(${self.config.label}:graphic_${item.id}_contents)`,
+				text: `$(${self.config.label}:graphic_${item.id}_${labelSource})`,
 				png64: pngIcon,
 				pngalignment: 'center:center',
 				size: '18',

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -124,6 +124,20 @@ export const init_http = (self) => {
 						variableId: `graphic_${id}_contents`,
 						name: label,
 					})
+					variables.push({
+						variableId: `graphic_${id}_label`,
+						name: label,
+					})
+					variableValues[`graphic_${id}_label`] = c.label || id
+
+					if (['lower_third', 'lower_third_animated'].includes(c.type)) {
+						variables.push({
+							variableId: `graphic_${id}_first_line`,
+							name: label,
+						})
+						variableValues[`graphic_${id}_first_line`] = c.line_one
+					}
+
 					if (
 						[
 							'time_countdown',


### PR DESCRIPTION
This PR adds two new sets of variables

- graphic_<id>_label - uses the label field if set, and the id if empty
- graphic_<id>_first_line - for lower_third and lower_third_animated graphics only

It also adds a config option to specify which variable (_label, _first_line or _contents) is used to generate presets

This addresses #13