### PR TITLE
Add dropdown options for PNG heading and preset button text size

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,35 @@ class H2RGraphicsInstance extends InstanceBase {
 				width: 3,
 				default: 'ABCD',
 			},
+			{
+				type: 'dropdown',
+				id: 'usePngForPresets',
+				label: 'Show PNG heading on Presets',
+				width: 6,
+				default: 'true',
+				choices: [
+					{ id: 'true', label: 'Yes' },
+					{ id: 'false', label: 'No' },
+				],
+			},
+			{
+				type: 'dropdown',
+				id: 'presetButtonTextSize',
+				label: 'Preset Button Text Size',
+				width: 6,
+				default: '18',
+				allowCustom: true,
+				regex: '/^(?:[0-9]+|auto)$/',
+				choices: [
+					{ id: 'auto', label: 'Auto' },
+					{ id: '7', label: '7pt' },
+					{ id: '14', label: '14pt'},
+					{ id: '18', label: '18pt' },
+					{ id: '24', label: '24pt' },
+					{ id: '30', label: '30pt'},
+					{ id: '33', label: '44pt' },
+				],
+			}		
 		]
 	}
 

--- a/src/presets.js
+++ b/src/presets.js
@@ -54,7 +54,7 @@ export const initPresets = (self) => {
 
 	const createPresetShowHide = (category, item) => {
 		let bgColour = graphicColours(item.type).bgColour
-		let pngIcon = graphicIcons(item.type).png
+		let pngIcon = self.config.usePngForPresets === 'true' ? graphicIcons(item.type).png : null
 		return {
 			category,
 			type: 'button',
@@ -63,7 +63,7 @@ export const initPresets = (self) => {
 				text: `$(${self.config.label}:graphic_${item.id}_contents)`,
 				png64: pngIcon,
 				pngalignment: 'center:center',
-				size: '18',
+				size: self.config.presetButtonTextSize || '18',
 				color: combineRgb(255, 255, 255),
 				bgcolor: combineRgb(bgColour[0], bgColour[1], bgColour[2]),
 				latch: false,


### PR DESCRIPTION
This PR adds two config options related to Presets

- font size
- whether to show PNG header

This will be useful to anyone who is working with lots of graphics