### PR TITLE
fix presets respecting "Show PNG heading on Presets" option

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -54,7 +54,7 @@ export const initPresets = (self) => {
 
 	const createPresetShowHide = (category, item) => {
 		let bgColour = graphicColours(item.type).bgColour
-		let pngIcon = graphicIcons(item.type).png
+		let pngIcon = self.config.usePngForPresets === 'true' ? graphicIcons(item.type).png : null
 		let labelSource = ['lower_third', 'lower_third_animated'].includes(item.type)
 			? self.config.lowerThirdPresetLabelSource || 'contents'
 			: 'contents'


### PR DESCRIPTION
This was from commit #a77482f but got accidentally reverted