### PR TITLE
replaceWithDataSource for first line variable

### DIFF
--- a/src/tcp.js
+++ b/src/tcp.js
@@ -66,7 +66,10 @@ export const init_http = (self) => {
 							variableId: `graphic_${id}_first_line`,
 							name: label,
 						})
-						variableValues[`graphic_${id}_first_line`] = c.line_one
+						variableValues[`graphic_${id}_first_line`] = replaceWithDataSource(
+							c.line_one,
+							self.SELECTED_PROJECT_VARIABLES,
+						)
 					}
 
 					if (['social'].includes(c.type)) {


### PR DESCRIPTION
this allows you to use [listx.y] in the lower thirds and have the correct value in the *_first_line variable (which you can use for the button text)