### PR TITLE
Improve launch_h2r.ahk reliability and portability

### DIFF
--- a/utils/launch_h2r.ahk
+++ b/utils/launch_h2r.ahk
@@ -1,4 +1,4 @@
-﻿#SingleInstance
+#SingleInstance
 ; customise these variables
 exe := "C:\<path stuff>\h2r-graphics-electron\H2R Graphics.exe"
 window_title := "Output 1 - <Project Name>"
@@ -6,26 +6,35 @@ url := "http://localhost:4001/api/<Project ID>/output/1/open"
 
 If !WinExist("ahk_exe H2R Graphics.exe") {
 	Run exe
-	Sleep 5000
+	WinWait "ahk_exe H2R Graphics.exe",, 30  ; Wait up to 30 seconds instead of fixed Sleep
 }
+
 If !WinExist(window_title) {
 	whr := ComObject("WinHttp.WinHttpRequest.5.1")
-	whr.Open("POST", url, true)
+	whr.Open("POST", url, false)  ; false = synchronous, simpler since you WaitForResponse anyway
 	whr.SetRequestHeader("Content-Type", "application/json")
 	whr.Send("{}")
-	whr.WaitForResponse()
+	; No need for WaitForResponse with synchronous request
 }
-	
-WinWait window_title
 
-; if the window is not maximized, maximize it
+WinWait window_title,, 30  ; Add timeout so it doesn't hang forever
+if !WinExist(window_title) {
+	MsgBox "Output window failed to open"
+	ExitApp
+}
+
+; Check if not fullscreen/maximized
 WinGetPos &X, &Y, &W, &H, window_title
-If (W != 1920)
+; Get the screen dimensions dynamically
+If (W != A_ScreenWidth)
 {
 	WinActivate window_title
+	Sleep 100
 	Send "^f"
 }
 
 Sleep 1000
+if WinExist("H2R Graphics")
+	WinMinimize "H2R Graphics"
 
-WinMinimize "H2R Graphics" ; just in case it pops up
+WinSetAlwaysOnTop true, window_title  ; Keep output on top of taskbar


### PR DESCRIPTION
## Summary
- Replace fixed `Sleep 5000` with `WinWait` + 30s timeout for app launch detection
- Switch HTTP request to synchronous mode (simplifies code, removes unnecessary `WaitForResponse`)
- Add timeout and error handling when waiting for the output window
- Use `A_ScreenWidth` instead of hardcoded `1920` for fullscreen detection
- Guard `WinMinimize` with `WinExist` check
- Add `WinSetAlwaysOnTop` to keep output window above the taskbar

## Test plan
- [ ] Run the AHK script on a Windows machine with H2R Graphics installed
- [ ] Verify the app launches and the output window opens correctly
- [ ] Verify fullscreen detection works on non-1920px displays
- [ ] Verify the output window stays on top of the taskbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)